### PR TITLE
chore(ping/overlays/dev/): bump daoquocquyen/ping to 1.0.0-abcdea

### DIFF
--- a/ping/overlays/dev/kustomization.yaml
+++ b/ping/overlays/dev/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - namespace.yaml
 images:
   - name: daoquocquyen/ping
-    newTag: 1.0.0-abcdef
+    newTag: 1.0.0-abcdea
 patches:
   - path: deployment-patch.yaml
   - path: ingress-patch.yaml


### PR DESCRIPTION
Update `ping/overlays/dev/kustomization.yaml` to set `newTag: 1.0.0-abcdea` for `daoquocquyen/ping`.