### PR TITLE
chore(pingpong-config/pong/overlays/dev): bump daoquocquyen/pong to 1.0.0-e2aeaa8

### DIFF
--- a/pong/overlays/dev/kustomization.yaml
+++ b/pong/overlays/dev/kustomization.yaml
@@ -6,6 +6,6 @@ resources:
   - namespace.yaml
 images:
   - name: daoquocquyen/pong
-    newTag: 1.0.0-340c758
+    newTag: 1.0.0-e2aeaa8
 patches:
   - path: deployment-patch.yaml


### PR DESCRIPTION
Update `kustomization.yaml` to set `newTag: 1.0.0-e2aeaa8` for `daoquocquyen/pong`.