### PR TITLE
chore(pingpong-config/ping/overlays/dev): bump daoquocquyen/ping to 1.0.0-83e47a2

### DIFF
--- a/ping/overlays/dev/kustomization.yaml
+++ b/ping/overlays/dev/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - namespace.yaml
 images:
   - name: daoquocquyen/ping
-    newTag: 1.0.0-29a4a7e
+    newTag: 1.0.0-83e47a2
 patches:
   - path: deployment-patch.yaml
   - path: ingress-patch.yaml


### PR DESCRIPTION
Update `kustomization.yaml` to set `newTag: 1.0.0-83e47a2` for `daoquocquyen/ping`.