### PR TITLE
Promote to Prod: ping 0.0.1, pong 0.0.2 (3792be6)

### DIFF
--- a/ping/overlays/prod/kustomization.yaml
+++ b/ping/overlays/prod/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - namespace.yaml
 images:
   - name: daoquocquyen/ping
-    newTag: 1.0.0-83e47a2
+    newTag: 0.0.1-ee278c4
 patches:
   - path: deployment-patch.yaml
   - path: ingress-patch.yaml

--- a/pong/overlays/prod/kustomization.yaml
+++ b/pong/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ resources:
   - configmap.yaml
 images:
   - name: daoquocquyen/pong
-    newTag: 1.0.0-a30ffaa
+    newTag: 0.0.2-c9243a6
 patches:
   - path: deployment-patch.yaml


### PR DESCRIPTION
Promote to Prod from QA baseline 3792be6e5f074396dce6ca6de7364a46e4f688e6. Release tags: ping=0.0.1, pong=0.0.2.