### PR TITLE
Promote to Prod: ping 0.0.3, pong 0.0.3 (eda58c1)

### DIFF
--- a/ping/overlays/prod/kustomization.yaml
+++ b/ping/overlays/prod/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - namespace.yaml
 images:
   - name: daoquocquyen/ping
-    newTag: 0.0.1-ee278c4
+    newTag: 0.0.3-30f410e
 patches:
   - path: deployment-patch.yaml
   - path: ingress-patch.yaml

--- a/pong/overlays/prod/kustomization.yaml
+++ b/pong/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ resources:
   - configmap.yaml
 images:
   - name: daoquocquyen/pong
-    newTag: 0.0.2-c9243a6
+    newTag: 0.0.3-c9243a6
 patches:
   - path: deployment-patch.yaml


### PR DESCRIPTION
Promote to Prod from QA baseline eda58c15394dd5e950b87d33ecaea39e1b93e87c. Release tags: ping=0.0.3, pong=0.0.3.